### PR TITLE
Makes __LINE__ test actually test the functionality of it

### DIFF
--- a/tests/dm/preprocessor/clang/builtin_line.dm
+++ b/tests/dm/preprocessor/clang/builtin_line.dm
@@ -2,7 +2,5 @@
 #define X(x) __LINE__
 
 /proc/main()
-  var/l = X(
-      1
-  )
+  var/l = X(1)
   LOG(l)


### PR DESCRIPTION
Currently BYOND just kinda throws a goofy error if you write a macro functor across multiple lines, for whatever reason. I don't think testing for that (kinda stinky) behaviour was the intent of this test, so I'm putting the macro call just on one line. :)